### PR TITLE
Thread save type re build

### DIFF
--- a/vk_feed_parser.sln
+++ b/vk_feed_parser.sln
@@ -19,8 +19,8 @@ Global
 		{916D82A4-DFB9-4012-81BE-5F1323C63FE2}.Debug|x86.Build.0 = Debug|x86
 		{916D82A4-DFB9-4012-81BE-5F1323C63FE2}.Release|x64.ActiveCfg = Release|Any CPU
 		{916D82A4-DFB9-4012-81BE-5F1323C63FE2}.Release|x64.Build.0 = Release|Any CPU
-		{916D82A4-DFB9-4012-81BE-5F1323C63FE2}.Release|x86.ActiveCfg = Release|Any CPU
-		{916D82A4-DFB9-4012-81BE-5F1323C63FE2}.Release|x86.Build.0 = Release|Any CPU
+		{916D82A4-DFB9-4012-81BE-5F1323C63FE2}.Release|x86.ActiveCfg = Release|x86
+		{916D82A4-DFB9-4012-81BE-5F1323C63FE2}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/vk_feed_parser/FileWorker.cs
+++ b/vk_feed_parser/FileWorker.cs
@@ -1,29 +1,48 @@
-﻿
-using System.IO;
+﻿using System.IO;
 using Newtonsoft.Json;
 
 namespace vk_feed_parser
 {
 	static class FileWorker
 	{
+		/// <summary>
+		/// A method that stores an object as a JSON.
+		/// </summary>
+		/// <param name="path">Final file location and name</param>
+		/// <param name="item">Serializing object</param>
 		public static void SaveToJsonFile(string path, object item, Formatting options = Formatting.Indented)
 		{
 			File.WriteAllText(path, JsonConvert.SerializeObject(item, options));
 		}
 
+		/// <summary>
+		/// Method unloads data from the specified JSON.
+		/// </summary>
+		/// <typeparam name="TItem">Type of uploaded data</typeparam>
+		/// <param name="path">A path to the file</param>
+		/// <returns>Deserialized object</returns>
 		public static TItem LoadFromJsonFile<TItem>(string path, JsonSerializerSettings settings = null)
 		{
 			return JsonConvert.DeserializeObject<TItem>(File.ReadAllText(path), settings);
 		}
 
+		/// <summary>
+		/// Creating new empty JSON files for saving data about text, links, images in 'DataStorages' folder, if they does not exists.
+		/// </summary>
 		public static void CreateEmptyFilesForSavingData()
 		{
-			if (!File.Exists("TestData.json"))
-				File.Create("TestData.json");
-			if (!File.Exists("LinksData.json"))
-				File.Create("LinksData.json");
-			if (!File.Exists("ImagesData.json"))
-				File.Create("ImagesData.json");
+			string rootFolder = Directory.GetCurrentDirectory();
+			string dataFilesFolder = "DataStorages";
+			string textDataPath = Path.Combine(rootFolder, dataFilesFolder, "TextData.json");
+			string linksDataPath = Path.Combine(rootFolder, dataFilesFolder, "LinksData.json");
+			string imagesDataPath = Path.Combine(rootFolder, dataFilesFolder, "ImagesData.json");
+			Directory.CreateDirectory(Path.Combine(rootFolder, dataFilesFolder));
+			if (!File.Exists(textDataPath))
+				File.Create(textDataPath);
+			if (!File.Exists(linksDataPath))
+				File.Create(linksDataPath);
+			if (!File.Exists(imagesDataPath))
+				File.Create(imagesDataPath);
 		}
 	}
 }

--- a/vk_feed_parser/FileWorker.cs
+++ b/vk_feed_parser/FileWorker.cs
@@ -15,5 +15,15 @@ namespace vk_feed_parser
 		{
 			return JsonConvert.DeserializeObject<TItem>(File.ReadAllText(path), settings);
 		}
+
+		public static void CreateEmptyFilesForSavingData()
+		{
+			if (!File.Exists("TestData.json"))
+				File.Create("TestData.json");
+			if (!File.Exists("LinksData.json"))
+				File.Create("LinksData.json");
+			if (!File.Exists("ImagesData.json"))
+				File.Create("ImagesData.json");
+		}
 	}
 }

--- a/vk_feed_parser/Parser.cs
+++ b/vk_feed_parser/Parser.cs
@@ -127,8 +127,8 @@ namespace vk_feed_parser
 				ThreadWorker worker = new ThreadWorker();
 				for (int i = 0; i < 10; i++)
 				{
-					while (!worker.IsStop) { }
 					worker.StartNewsSaving(GetPostsList(100));
+					while (!worker.IsStop) { }
 				}
 				UIWorker.AddRecord("Parsing ended!!!");
 			});

--- a/vk_feed_parser/Parser.cs
+++ b/vk_feed_parser/Parser.cs
@@ -101,6 +101,18 @@ namespace vk_feed_parser
 				StartFrom = nextFrom
 			});
 			nextFrom = newsFeed.NextFrom;
+
+			new Thread(() =>
+			{
+				var postsDataList = (from item in newsFeed.Items.ToList()
+									 select PostData.SeparatePost(item)).ToList();
+				foreach (var i in postsDataList)
+				{
+					UIWorker.AddRecord(i.ToString());
+				}
+			}
+			).Start();
+
 			return newsFeed;
 		}
 

--- a/vk_feed_parser/Parser.cs
+++ b/vk_feed_parser/Parser.cs
@@ -73,7 +73,7 @@ namespace vk_feed_parser
 		}
 
 		//	https://github.com/vudeam - is owner of this method idea.
-		private List<TAttType> GetAttachments<TAttType>(NewsItem post) where TAttType : class
+		public static List<TAttType> GetAttachments<TAttType>(NewsItem post) where TAttType : class
 		{
 			if (post.Attachments != null)
 			{
@@ -87,46 +87,17 @@ namespace vk_feed_parser
 			}
 		}
 
-
-		public PostData SeparatePost(NewsItem post)
-		{
-			string id = $"{post.SourceId}_{post.PostId}";
-			List<string> Images = GetAttachments<Photo>(post).ConvertAll(i => i.Sizes.Last().Url.ToString());
-			List<string> Links = GetAttachments<Link>(post).ConvertAll(i => i.Uri.ToString());
-
-			PostData postData = new PostData()
-			{
-				textData = {
-					postID = id,
-					postText = post.Text
-				},
-				imagesData =
-				{
-					postID = id,
-					postImages = Images
-				},
-				linksData =
-				{
-					postID = id,
-					postLinks = Links					
-				}
-			};
-
-			return postData;
-		}
-
 		public Thread GetParseThread()
 		{
 			var thread = new Thread(() =>
 			{
 				var postsDataList = (from item in GetPostsArr(5)
-				 select SeparatePost(item)).ToList();
+				 select PostData.SeparatePost(item)).ToList();
 				foreach (var i in postsDataList)
 				{
 					UIWorker.AddRecord(i.ToString());
 				}
 			});
-
 			return thread;
 		}
 	}

--- a/vk_feed_parser/Parser.cs
+++ b/vk_feed_parser/Parser.cs
@@ -135,15 +135,12 @@ namespace vk_feed_parser
 		{
 			var thread = new Thread(() =>
 			{
-				IEnumerable<NewsItem> posts = GetPostsList(1000);
-				var postsDataList = (from item in posts
-				 select PostData.SeparatePost(item)).ToList();
-				foreach (var i in postsDataList)
+				ThreadWorker worker = new ThreadWorker();
+				for (int i = 0; i < 10; i++)
 				{
-					UIWorker.AddRecord(i.ToString());
+					while (!worker.IsStop) { }
+					worker.StartNewsSaving(GetPostsList(1000));
 				}
-				ThreadWorker worker = new ThreadWorker(posts);
-				worker.StartNewsSaving();
 			});
 			return thread;
 		}

--- a/vk_feed_parser/Parser.cs
+++ b/vk_feed_parser/Parser.cs
@@ -102,17 +102,6 @@ namespace vk_feed_parser
 			});
 			nextFrom = newsFeed.NextFrom;
 
-			new Thread(() =>
-			{
-				var postsDataList = (from item in newsFeed.Items.ToList()
-									 select PostData.SeparatePost(item)).ToList();
-				foreach (var i in postsDataList)
-				{
-					UIWorker.AddRecord(i.ToString());
-				}
-			}
-			).Start();
-
 			return newsFeed;
 		}
 
@@ -139,8 +128,9 @@ namespace vk_feed_parser
 				for (int i = 0; i < 10; i++)
 				{
 					while (!worker.IsStop) { }
-					worker.StartNewsSaving(GetPostsList(1000));
+					worker.StartNewsSaving(GetPostsList(100));
 				}
+				UIWorker.AddRecord("Parsing ended!!!");
 			});
 			return thread;
 		}

--- a/vk_feed_parser/Parser.cs
+++ b/vk_feed_parser/Parser.cs
@@ -125,7 +125,7 @@ namespace vk_feed_parser
 			var thread = new Thread(() =>
 			{
 				ThreadWorker worker = new ThreadWorker();
-				for (int i = 0; i < 10; i++)
+				for (int i = 0; i < 1; i++)
 				{
 					worker.StartNewsSaving(GetPostsList(100));
 					while (!worker.IsStop) { }

--- a/vk_feed_parser/Parser.cs
+++ b/vk_feed_parser/Parser.cs
@@ -58,18 +58,50 @@ namespace vk_feed_parser
 			return di;
 		}
 
-		public IEnumerable<NewsItem> GetPostsArr(ushort newsCount)
+		/// <summary>
+		/// Gets specified number of posts.
+		/// </summary>
+		/// <param name="newsCount">The number of posts requested.</param>
+		/// <returns>Returns the received posts.</returns>
+		public List<NewsItem> GetPostsList(uint newsCount)
 		{
-			NewsFeed newsFeed = api.NewsFeed.Get(new NewsFeedGetParams() 
-			{ 
+			if (newsCount == 0) return new List<NewsItem>();
+
+			var newsItems = new List<NewsItem>();
+			uint requestNumber;
+			ushort residualAmount;
+			if (newsCount > 100)
+			{
+				requestNumber = newsCount / 100;
+				residualAmount = (ushort)(newsCount - requestNumber * 100);
+			}
+			else
+			{
+				requestNumber = 0;
+				residualAmount = (ushort)newsCount;
+			}
+			for (uint i = 0; i < requestNumber; i++)
+				newsItems.AddRange(GetNewsFeed(100).Items.ToList());
+			if (residualAmount > 0)
+				newsItems.AddRange(GetNewsFeed(residualAmount).Items.ToList());
+			return newsItems;
+		}
+
+		/// <summary>
+		/// Gets a NewsFeed with the specified number of posts.
+		/// </summary>
+		/// <param name="count">The number of posts requested. Less than or equal to 100.</param>
+		/// <returns>Returns the received NewsFeed.</returns>
+		private NewsFeed GetNewsFeed(ushort count)
+		{
+			NewsFeed newsFeed = api.NewsFeed.Get(new NewsFeedGetParams()
+			{
 				Filters = NewsTypes.Post,
-				Count = newsCount,
+				Count = count,
 				StartFrom = nextFrom
 			});
-
 			nextFrom = newsFeed.NextFrom;
-
-			return newsFeed.Items;
+			return newsFeed;
 		}
 
 		//	https://github.com/vudeam - is owner of this method idea.
@@ -91,12 +123,15 @@ namespace vk_feed_parser
 		{
 			var thread = new Thread(() =>
 			{
-				var postsDataList = (from item in GetPostsArr(5)
+				IEnumerable<NewsItem> posts = GetPostsList(1000);
+				var postsDataList = (from item in posts
 				 select PostData.SeparatePost(item)).ToList();
 				foreach (var i in postsDataList)
 				{
 					UIWorker.AddRecord(i.ToString());
 				}
+				ThreadWorker worker = new ThreadWorker(posts);
+				worker.StartNewsSaving();
 			});
 			return thread;
 		}

--- a/vk_feed_parser/PostData.cs
+++ b/vk_feed_parser/PostData.cs
@@ -75,5 +75,32 @@ namespace vk_feed_parser
 			};
 			return postData;
 		}
+
+		public static PostData.TextData SeparateText(NewsItem post)
+		{
+			return new PostData.TextData()
+			{
+				postID = $"{post.SourceId}_{post.PostId}",
+				postText = post.Text
+			};
+		}
+
+		public static PostData.LinksData SeparateLinks(NewsItem post)
+		{
+			return new PostData.LinksData()
+			{
+				postID = $"{post.SourceId}_{post.PostId}",
+				postLinks = Parser.GetAttachments<Link>(post).ConvertAll(i => i.Uri.ToString())
+			};
+		}
+
+		public static PostData.ImagesData SeparateImages(NewsItem post)
+		{
+			return new PostData.ImagesData()
+			{
+				postID = $"{post.SourceId}_{post.PostId}",
+				postImages = Parser.GetAttachments<Photo>(post).ConvertAll(i => i.Sizes[^1].Url.ToString())
+			};
+		}
 	}
 }

--- a/vk_feed_parser/PostData.cs
+++ b/vk_feed_parser/PostData.cs
@@ -46,7 +46,7 @@ namespace vk_feed_parser
 	class PostDataEqualityComparer : IEqualityComparer<PostData>
 	{
 		public bool Equals([AllowNull] PostData x, [AllowNull] PostData y) =>
-			x.postId == y.postId ? true : false;
+			x.postId.Equals(y.postId);
 
 		public int GetHashCode([DisallowNull] PostData obj) => 
 			obj.postId.GetHashCode();

--- a/vk_feed_parser/PostData.cs
+++ b/vk_feed_parser/PostData.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Text;
+using VkNet.Model;
+using VkNet.Model.Attachments;
 
 namespace vk_feed_parser
 {
@@ -46,6 +48,32 @@ namespace vk_feed_parser
 				$"\"Text\": {textData.postText}\n" +
 				$"\"Links\": {links}\n" +
 				$"\"Images\": {imgs}\n";
+		}
+
+		public static PostData SeparatePost(NewsItem post)
+		{
+			string id = $"{post.SourceId}_{post.PostId}";
+			List<string> Images = Parser.GetAttachments<Photo>(post).ConvertAll(i => i.Sizes[^1].Url.ToString());
+			List<string> Links = Parser.GetAttachments<Link>(post).ConvertAll(i => i.Uri.ToString());
+
+			PostData postData = new PostData()
+			{
+				textData = {
+					postID = id,
+					postText = post.Text
+				},
+				imagesData =
+				{
+					postID = id,
+					postImages = Images
+				},
+				linksData =
+				{
+					postID = id,
+					postLinks = Links
+				}
+			};
+			return postData;
 		}
 	}
 }

--- a/vk_feed_parser/PostData.cs
+++ b/vk_feed_parser/PostData.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using VkNet.Model;
 using VkNet.Model.Attachments;
 
@@ -39,5 +41,14 @@ namespace vk_feed_parser
 			postId = $"{post.SourceId}_{post.PostId}",
 			postContent = Parser.GetAttachments<Photo>(post).ConvertAll(i => i.Sizes[^1].Url.ToString())
 		};
+	}
+
+	class PostDataEqualityComparer : IEqualityComparer<PostData>
+	{
+		public bool Equals([AllowNull] PostData x, [AllowNull] PostData y) =>
+			x.postId == y.postId ? true : false;
+
+		public int GetHashCode([DisallowNull] PostData obj) => 
+			obj.postId.GetHashCode();
 	}
 }

--- a/vk_feed_parser/PostData.cs
+++ b/vk_feed_parser/PostData.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using System.Text;
 using VkNet.Model;
 using VkNet.Model.Attachments;
 
@@ -9,98 +7,37 @@ namespace vk_feed_parser
 {
 	public class PostData
 	{
-		public struct TextData
-		{
-			public string postID;
-			public string postText;
-		}
-		
-		public struct ImagesData
-		{
-			public string postID;
-			public List<string> postImages; 
-		}
-
-		public struct LinksData
-		{
-			public string postID;
-			public List<string> postLinks;
-		}
-
-		public TextData textData;
-		public ImagesData imagesData;
-		public LinksData linksData;
+		public string postId;
+		public List<string> postContent;
 
 		public override string ToString()
 		{
-			string imgs = string.Empty;
-			string links = string.Empty;
-			foreach (var i in imagesData.postImages)
+			string content = string.Empty;
+			foreach (var i in postContent)
 			{
-				imgs += i + Environment.NewLine;
-			}
-			foreach (var i in linksData.postLinks)
-			{
-				links += i + Environment.NewLine;
+				content += i + Environment.NewLine;
 			}
 
-			return $"\"Id\": {textData.postID}\n" +
-				$"\"Text\": {textData.postText}\n" +
-				$"\"Links\": {links}\n" +
-				$"\"Images\": {imgs}\n";
+			return $"\"Id\": {postId}\n" +
+				$"\"Content\": {content}\n";
 		}
 
-		public static PostData SeparatePost(NewsItem post)
+		public static PostData SeparateText(NewsItem post) => new PostData()
 		{
-			string id = $"{post.SourceId}_{post.PostId}";
-			List<string> Images = Parser.GetAttachments<Photo>(post).ConvertAll(i => i.Sizes[^1].Url.ToString());
-			List<string> Links = Parser.GetAttachments<Link>(post).ConvertAll(i => i.Uri.ToString());
+			postId = $"{post.SourceId}_{post.PostId}",
+			postContent = new List<string>() { post.Text }
+		};
 
-			PostData postData = new PostData()
-			{
-				textData = {
-					postID = id,
-					postText = post.Text
-				},
-				imagesData =
-				{
-					postID = id,
-					postImages = Images
-				},
-				linksData =
-				{
-					postID = id,
-					postLinks = Links
-				}
-			};
-			return postData;
-		}
-
-		public static PostData.TextData SeparateText(NewsItem post)
+		public static PostData SeparateLinks(NewsItem post) => new PostData()
 		{
-			return new PostData.TextData()
-			{
-				postID = $"{post.SourceId}_{post.PostId}",
-				postText = post.Text
-			};
-		}
+			postId = $"{post.SourceId}_{post.PostId}",
+			postContent = Parser.GetAttachments<Link>(post).ConvertAll(i => i.Uri.ToString())
+		};
 
-		public static PostData.LinksData SeparateLinks(NewsItem post)
+		public static PostData SeparateImages(NewsItem post) => new PostData()
 		{
-			return new PostData.LinksData()
-			{
-				postID = $"{post.SourceId}_{post.PostId}",
-				postLinks = Parser.GetAttachments<Link>(post).ConvertAll(i => i.Uri.ToString())
-			};
-		}
-
-		public static PostData.ImagesData SeparateImages(NewsItem post)
-		{
-			return new PostData.ImagesData()
-			{
-				postID = $"{post.SourceId}_{post.PostId}",
-				postImages = Parser.GetAttachments<Photo>(post).ConvertAll(i => i.Sizes[^1].Url.ToString())
-			};
-		}
+			postId = $"{post.SourceId}_{post.PostId}",
+			postContent = Parser.GetAttachments<Photo>(post).ConvertAll(i => i.Sizes[^1].Url.ToString())
+		};
 	}
 }

--- a/vk_feed_parser/ThreadWorker.cs
+++ b/vk_feed_parser/ThreadWorker.cs
@@ -21,7 +21,12 @@ namespace vk_feed_parser
 			new List<PostData.ImagesData>()
 		};
 		object[] threadsLokers = new object[dataStorages.Count];
-		string[] paths = new string[dataStorages.Count];
+		string[] paths = new string[]
+		{
+			"TextData.json",
+			"LinksData.json",
+			"ImagesData.json"
+		};
 
 		public ThreadWorker(IEnumerable<NewsItem> posts)
 		{
@@ -104,6 +109,7 @@ namespace vk_feed_parser
 
 		public void StartNewsSaving()
 		{
+			FileWorker.CreateEmptyFilesForSavingData();
 			var packingThreads = new Thread[]
 			{
 				GetPackingThread(

--- a/vk_feed_parser/ThreadWorker.cs
+++ b/vk_feed_parser/ThreadWorker.cs
@@ -139,6 +139,14 @@ namespace vk_feed_parser
 			}
 			savingThread = GetSavingThread();
 
+			new Thread((object p)=> 
+			{
+				foreach (var item in p as IEnumerable<NewsItem>)
+				{
+					UIWorker.AddRecord($"{item.SourceId}_{item.PostId}");
+				}
+			}).Start(posts);
+
 			foreach (var item in packingThreads) item.Start();
 			savingThread.Start();
 		}

--- a/vk_feed_parser/ThreadWorker.cs
+++ b/vk_feed_parser/ThreadWorker.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace vk_feed_parser
+{
+	public class ThreadWorker
+	{
+
+	}
+}

--- a/vk_feed_parser/ThreadWorker.cs
+++ b/vk_feed_parser/ThreadWorker.cs
@@ -3,27 +3,45 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using VkNet.Model;
+using System.Linq;
 
 namespace vk_feed_parser
 {
 	public class ThreadWorker
 	{
 		Queue<NewsItem> posts;
-		static object queueGetLocker = new object();
+		static object getQueueLocker = new object();
 
 		public ThreadWorker(IEnumerable<NewsItem> posts)
 		{
 			this.posts = new Queue<NewsItem>(posts);
 		}
 
-		public Thread GetPackingThread()
+		public Thread GetPackingThread<TData>(
+			object locker, 
+			string path, 
+			Func<NewsItem, TData> SeparateData, 
+			List<TData> dataList
+			)
 		{
 			return new Thread(() =>
 			{
+				const uint range = 10;
+				var bufData = new List<TData>();
 				Queue<NewsItem> localPosts;
-				lock (queueGetLocker)
+				lock (getQueueLocker)
 				{
 					localPosts = posts;
+				}
+				while (localPosts.Count != 0)
+				{
+					lock (locker)
+					{
+						for (int i = 0; i < range; i++)
+							bufData.Add(SeparateData(localPosts.Dequeue()));
+						var externalData = FileWorker.LoadFromJsonFile<List<TData>>(path);
+						dataList.AddRange(bufData.Except(externalData));
+					}
 				}
 			});
 		}

--- a/vk_feed_parser/ThreadWorker.cs
+++ b/vk_feed_parser/ThreadWorker.cs
@@ -71,7 +71,10 @@ namespace vk_feed_parser
 							if (localPosts.Count != 0)
 								bufData.Add(SeparateData(localPosts.Dequeue()));
 						var externalData = FileWorker.LoadFromJsonFile<List<PostData>>(path);
-						dataList.AddRange(bufData.Except(externalData ?? new List<PostData>()));
+						dataList.AddRange(bufData.Except(
+							externalData ?? new List<PostData>(),
+							new PostDataEqualityComparer()
+							));
 						bufData.Clear();
 					}
 					Thread.Sleep(5);

--- a/vk_feed_parser/ThreadWorker.cs
+++ b/vk_feed_parser/ThreadWorker.cs
@@ -101,5 +101,35 @@ namespace vk_feed_parser
 			bufList.AddRange(dataStorages[index] as List<TData>);
 			FileWorker.SaveToJsonFile(paths[index], bufList);
 		}
+
+		public void StartNewsSaving()
+		{
+			var packingThreads = new Thread[]
+			{
+				GetPackingThread(
+					threadsLokers[0], 
+					paths[0], 
+					PostData.SeparateText,
+					dataStorages[0] as List<PostData.TextData>),
+				GetPackingThread(
+					threadsLokers[1],
+					paths[1],
+					PostData.SeparateLinks,
+					dataStorages[1] as List<PostData.LinksData>),
+				GetPackingThread(
+					threadsLokers[2],
+					paths[2],
+					PostData.SeparateImages,
+					dataStorages[2] as List<PostData.ImagesData>)
+			};
+			var savingThread = GetSavingThread();
+
+			foreach (var item in packingThreads)
+			{
+				item.Start();
+			}
+
+			savingThread.Start();
+		}
 	}
 }

--- a/vk_feed_parser/ThreadWorker.cs
+++ b/vk_feed_parser/ThreadWorker.cs
@@ -2,11 +2,30 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using VkNet.Model;
 
 namespace vk_feed_parser
 {
 	public class ThreadWorker
 	{
+		Queue<NewsItem> posts;
+		static object queueGetLocker = new object();
 
+		public ThreadWorker(IEnumerable<NewsItem> posts)
+		{
+			this.posts = new Queue<NewsItem>(posts);
+		}
+
+		public Thread GetPackingThread()
+		{
+			return new Thread(() =>
+			{
+				Queue<NewsItem> localPosts;
+				lock (queueGetLocker)
+				{
+					localPosts = posts;
+				}
+			});
+		}
 	}
 }

--- a/vk_feed_parser/ThreadWorker.cs
+++ b/vk_feed_parser/ThreadWorker.cs
@@ -95,7 +95,7 @@ namespace vk_feed_parser
 						lock (threadsLokers[targetIndex])
 						{
 							UniteAndSaveData(dataStorages[targetIndex], paths[targetIndex]);
-							(dataStorages[targetIndex]).Clear();
+							dataStorages[targetIndex].Clear();
 						}
 						if (CheckStopCondition()) StopNewsSaving();
 					}

--- a/vk_feed_parser/ThreadWorker.cs
+++ b/vk_feed_parser/ThreadWorker.cs
@@ -12,6 +12,15 @@ namespace vk_feed_parser
 		Queue<NewsItem> posts;
 		static object getQueueLocker = new object();
 
+		// fields to pass to the method
+		const uint numOfThreads = 3;
+		object[] threadsLokers = new object[numOfThreads];
+		string[] paths = new string[numOfThreads];
+		List<PostData.TextData> textDataList;
+		List<PostData.LinksData> linksDataList;
+		List<PostData.ImagesData> imagesDataList;
+
+
 		public ThreadWorker(IEnumerable<NewsItem> posts)
 		{
 			this.posts = new Queue<NewsItem>(posts);
@@ -43,6 +52,13 @@ namespace vk_feed_parser
 						dataList.AddRange(bufData.Except(externalData));
 					}
 				}
+			});
+		}
+
+		public Thread GetSavingThread()
+		{
+			return new Thread(() =>
+			{
 			});
 		}
 	}

--- a/vk_feed_parser/UIWorker.cs
+++ b/vk_feed_parser/UIWorker.cs
@@ -12,17 +12,21 @@ namespace vk_feed_parser
 	public static class UIWorker
 	{
 		public static Dispatcher mainDispatcher;
-		public static StackPanel mainPanel;
+		public static Dispatcher logDispatcher;
+		public static StackPanel logPanel;
 
-		public static void SetWriterParams(Dispatcher disp, StackPanel panel)
+		public static void SetWriterParams(Dispatcher mDisp, StackPanel panel)
 		{
-			mainDispatcher = disp;
-			mainPanel = panel;
+			mainDispatcher = mDisp;
+			logPanel = panel;
+			logDispatcher = panel.Dispatcher;
 		}
 
 		public static void AddRecord(String text)
 		{
-			mainDispatcher.Invoke(() => {
+			logDispatcher.Invoke(() => {
+				bool onBottom = (logPanel.Parent as ScrollViewer).VerticalOffset == 
+				(logPanel.Parent as ScrollViewer).ScrollableHeight;
 				var tBlock = new TextBox
 				{
 					IsReadOnly = true,
@@ -32,13 +36,11 @@ namespace vk_feed_parser
 					FontFamily = new FontFamily("Consolas"),
 					Text = "> "
 				};
-			try
-			{
 				tBlock.Text += text;
-				mainPanel.Children.Add(tBlock);
-			}
-			catch { }
-		});
+				logPanel.Children.Add(tBlock);
+
+				if (onBottom) (logPanel.Parent as ScrollViewer).ScrollToBottom();
+			});
 		}
 
 		public static void SetLineState(Rectangle line, bool state)

--- a/vk_feed_parser/Windows/MainWindow.xaml.cs
+++ b/vk_feed_parser/Windows/MainWindow.xaml.cs
@@ -33,6 +33,7 @@ namespace vk_feed_parser.Windows
 		private void Window_Loaded(object sender, RoutedEventArgs e)
 		{
 			Config.CheckConfigFileValid();
+			FileWorker.CreateEmptyFilesForSavingData();
 			UIWorker.SetWriterParams(Dispatcher, logStack);
 			UIWorker.AddRecord("Welcome to VkFeedParcer 3000");
 		}

--- a/vk_feed_parser/Windows/MainWindow.xaml.cs
+++ b/vk_feed_parser/Windows/MainWindow.xaml.cs
@@ -106,6 +106,20 @@ namespace vk_feed_parser.Windows
 			{
 				Thread parsingThread = parser.GetParseThread();
 				parsingThread.Start();
+				this.Dispatcher.Invoke(() =>
+				{
+					setPreferencesBtn.IsEnabled = false;
+					runParseBtn.IsEnabled = false;
+				});
+				new Thread(()=>
+				{
+					parsingThread.Join();
+					this.Dispatcher.Invoke(() =>
+					{
+						setPreferencesBtn.IsEnabled = true;
+						runParseBtn.IsEnabled = true;
+					});
+				}).Start();
 			}
 		}
 	}

--- a/vk_feed_parser/vk_feed_parser.csproj
+++ b/vk_feed_parser/vk_feed_parser.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Flurl.Http" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="VkNet" Version="1.60.0" />
+    <PackageReference Include="VkNet" Version="1.61.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I added a procedure for saving received news to files by different streams. The streams are synchronized, which means that no multiple access exception is thrown.
There is a problem getting over 2000 news items. Presumably this is due to the limitation of the VkNrt library.